### PR TITLE
Fix form submission for "Extend a residence title"

### DIFF
--- a/src/main/java/org/example/formhandlers/Section2ServiceSelectionHandler.java
+++ b/src/main/java/org/example/formhandlers/Section2ServiceSelectionHandler.java
@@ -53,7 +53,7 @@ public class Section2ServiceSelectionHandler implements IFormHandler {
 
     public boolean fillAndSendForm() throws InterruptedException {
         fillForm();
-        if (serviceTypeLabelValue.equals("Apply for a permanent settlement permit")) {
+        if (serviceTypeLabelValue.equals("Apply for a permanent settlement permit") || serviceTypeLabelValue.equals("Extend a residence title")) {
             sendForm();
         }
         try {


### PR DESCRIPTION
We should click on the Next button when service type is "Extend a residence title".